### PR TITLE
fix: use PulseAudio as the default audio output

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+audacious-plugins (4.3.1-3deepin1) unstable; urgency=medium
+
+  * Give the PulseAudio audio output plugin higher priority to that of
+    PipeWire's. Under a PulseAudio setup, the PipeWire output may be selected
+    by default, which would promptly fail to work, as there is no PipeWire
+    server/proxy running.
+  * On the other hand, under a PipeWire setup, PulseAudio output would still
+    work normally, as pipewire-pulse acts as a PulseAudio server.
+  * Making PulseAudio the top preference allows for better compatibility for
+    different setups, especially for distributions that have not (yet)
+    switched to PipeWire as the default audio server.
+
+ -- Mingcong Bai <baimingcong@uniontech.com>  Wed, 28 Aug 2024 16:57:03 +0800
+
 audacious-plugins (4.3.1-3) unstable; urgency=medium
 
   * Team upload.

--- a/debian/patches/0001-fix-pulse-give-PulseAudio-output-plugin-higher-prior.patch
+++ b/debian/patches/0001-fix-pulse-give-PulseAudio-output-plugin-higher-prior.patch
@@ -1,0 +1,49 @@
+From 19fe3d1cf7f6bea2e820f78223f85a59220142ca Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Wed, 28 Aug 2024 16:27:44 +0800
+Subject: [PATCH] fix(pulse): give PulseAudio output plugin higher priority
+ than PipeWire
+
+Give the PulseAudio audio output plugin higher priority to that of PipeWire's.
+Under a PulseAudio setup, the PipeWire output may be selected by default,
+which would promptly fail to work, as there is no PipeWire server/proxy
+running.
+
+On the other hand, under a PipeWire setup, PulseAudio output would still work
+normally, as pipewire-pulse acts as a PulseAudio server.
+
+Making PulseAudio the top preference allows for better compatibility for
+different setups, especially for distributions that have not (yet) switched to
+PipeWire as the default audio server.
+---
+ src/pulse/pulse_audio.cc | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/src/pulse/pulse_audio.cc b/src/pulse/pulse_audio.cc
+index db10e8cec..d2197a047 100644
+--- a/src/pulse/pulse_audio.cc
++++ b/src/pulse/pulse_audio.cc
+@@ -45,7 +45,19 @@ public:
+         & prefs
+     };
+ 
+-    constexpr PulseOutput () : OutputPlugin (info, 8) {}
++    /*
++     * Set a higher priority to that of PipeWire. Under a PulseAudio setup,
++     * the PipeWire output may be selected by default, which would promptly
++     * fail to work, as there is no PipeWire server/proxy running.
++     *
++     * On the other hand, under a PipeWire setup, PulseAudio output would
++     * still work normally, as pipewire-pulse acts as a PulseAudio server.
++     *
++     * Making PulseAudio the top preference allows for better compatibility
++     * for different setups, especially for distributions that have not (yet)
++     * switched to PipeWire as the default audio server.
++     */
++    constexpr PulseOutput () : OutputPlugin (info, 9) {}
+ 
+     bool init ();
+     void cleanup ();
+-- 
+2.46.0
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,5 @@
 0001-Do-not-hard-code-build-architecture-pkg-config.patch
+
+# Use PulseAudio output plugin by default for better compatibility with both
+# PulseAudio and PipeWire setups.
+0001-fix-pulse-give-PulseAudio-output-plugin-higher-prior.patch


### PR DESCRIPTION
Give the PulseAudio audio output plugin higher priority to that of PipeWire's. Under a PulseAudio setup, the PipeWire output may be selected by default, which would promptly fail to work, as there is no PipeWire server/proxy running.

On the other hand, under a PipeWire setup, PulseAudio output would still work normally, as pipewire-pulse acts as a PulseAudio server.

Making PulseAudio the top preference allows for better compatibility for different setups, especially for distributions that have not (yet) switched to PipeWire as the default audio server.